### PR TITLE
added default and size attributes

### DIFF
--- a/src/GravatarTagHelper/GravatarTagHelper.cs
+++ b/src/GravatarTagHelper/GravatarTagHelper.cs
@@ -7,26 +7,40 @@ namespace GravatarTagHelper
     [TargetElement("img", Attributes=EmailAttributeName)]
 	public class GravatarTagHelper : TagHelper
 	{
-        private const string EmailAttributeName="gravatar-email";
-        
+        private const string EmailAttributeName = "gravatar-email";
+
         [HtmlAttributeName(EmailAttributeName)]
         public string EmailAddress { get; set; }
-        
-		public override void Process(TagHelperContext context, TagHelperOutput output)
+        public int? GravatarSize { get; set; }
+
+        public string GravatarDefault { get; set; }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            using(var md5 = MD5.Create())
-            {                
+            using (var md5 = MD5.Create())
+            {
                 byte[] hash = md5.ComputeHash(Encoding.UTF8.GetBytes(EmailAddress));
-                
-                // Build the final string by converting each byte
+
+                // Build the hash string by converting each byte
                 // into hex and appending it to a StringBuilder
                 StringBuilder sb = new StringBuilder();
-                for (int i=0;i<hash.Length;i++)
+                for (int i = 0; i < hash.Length; i++)
                 {
                     sb.Append(hash[i].ToString("x2"));
                 }
-                output.Attributes["src"] ="http://www.gravatar.com/avatar/" +  sb.ToString();
+
+                var url = "http://www.gravatar.com/avatar/" + sb.ToString();
+                if (!string.IsNullOrEmpty(GravatarDefault))
+                {
+                    url += "?d=" + GravatarDefault;
+                }
+
+                if (GravatarSize != null)
+                {
+                    url += "?s=" + GravatarSize;
+                }
+                output.Attributes["src"] = url;
             }
-	   }
+        }
     }
 }


### PR DESCRIPTION
hi there - thanks for this - first google result for "taghelper gravatar"
I added some extra attributes.
I can't get the solution to compile in my VS 2015 RC (before my commit), but the code works great in my solution.

usage example:
`<img class="nav-user-photo" gravatar-email="@Model.User.Email" gravatar-default="retro" />`

(i didn't need the attribute on the property - latest mvc is automatically converting camelcase tag property to dashed attribute on tag)
